### PR TITLE
fix(github-actions): group all workflow updates

### DIFF
--- a/main.json
+++ b/main.json
@@ -14,6 +14,10 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "matchCurrentVersion": "!/^0/",
       "automerge": true
+    },
+    {
+      "groupName": "GitHub Actions",
+      "matchManagers": ["github-actions"]
     }
   ]
 }


### PR DESCRIPTION
This will group all GitHub Actions workflow file updates; as it sees the new "uses" field released, it will update a single PR.

Reference: [https://docs.renovatebot.com/configuration-options/#matchmanagers](https://docs.renovatebot.com/configuration-options/#matchmanagers:~:text=%7D%0A%20%20%5D%0A%7D-,matchManagers,-%C2%B6)